### PR TITLE
Fix for 'MixedContent' error in browser when running behind HTTPS proxy

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -43,7 +43,7 @@ module.exports = function(config, auth, storage) {
   app.get('/', function(req, res, next) {
     var base = config.url_prefix
              ? config.url_prefix.replace(/\/$/, '')
-             : req.protocol + '://' + req.get('host')
+             : ''
     res.setHeader('Content-Type', 'text/html')
 
     storage.get_local(function(err, packages) {


### PR DESCRIPTION
When using sinopia behind a HTTPS proxy (e.g. with [rnbwd/sinopia](https://github.com/RnbWd/sinopia-docker)) CSS, favicon and other resources are loaded from the HTTP URL. This causes a [MixedContent](https://developer.mozilla.org/en-US/docs/Security/Mixed_content/How_to_fix_website_with_mixed_content) error in most modern browsers, preventing i.e. the CSS file to be loaded.

This pull request removes setting the 'base' URL explicitly, because 'req.protocol' contains 'HTTP' when a HTTPS proxy is forwarding the request. Leaving the 'base' URL empty makes the browser choose the correct protocol automatically. 