### PR TITLE
Add support for using Windows named pipes

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -152,7 +152,7 @@ function afterConfigLoad() {
     logger.logger.warn({
       addr: ( addr.path
             ? URL.format({
-                protocol: 'unix',
+                protocol: addr.proto || 'unix',
                 pathname: addr.path,
               })
             : URL.format({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,6 +153,15 @@ module.exports.parse_address = function parse_address(addr) {
     path:  m[4],
   }
 
+  // Windows named pipe
+  //          \\ . \pipe\  (PipeName)
+  var m = /^\\\\\.\\pipe\\[^\\]+$/.exec(addr)
+
+  if (m) return {
+    proto: 'winpipe',
+    path: addr
+  }
+
   return null
 }
 

--- a/test/unit/listen_addr.js
+++ b/test/unit/listen_addr.js
@@ -39,4 +39,9 @@ describe('Parse address', function() {
   addTest('blah://4873', null)
   addTest('https://blah:4873///', null)
   addTest('unix:1234', 'http', 'unix', '1234') // not unix socket
+
+  addTest('\\\\.\\pipe\\01a96932-567e-41e8-9bed-0eba99ec769b', 'winpipe','\\\\.\\pipe\\01a96932-567e-41e8-9bed-0eba99ec769b')
+  addTest('\\\\.\\pipe', null)
+  addTest('\\\\.\\pipe\\', null)
+  addTest('\\\\.\\pipe\\foo\\bar', null)
 })


### PR DESCRIPTION
#### Background

One very common way of hosting node applications on Windows is to host them in [IIS](https://www.iis.net/) using [iisnode](https://github.com/tjanczuk/iisnode).


iisnode provides the available port as a Windows named pipe and not as a port number in the environment variable `port`. Node can open named pipes, however the `parse_address()` function in `utils.js` does not allow them, so Sinopia cannot be hosted in iisnode on Windows.

This PR fixes that. 

#### What's changed
This PR does not change any of the existing behavior, if a port number or url has been specified it's still used. 

However, if it's not one of those a check is made to see if the incoming port looks like a Windows named pipe, and in that case uses that. 
This PR also fixes logging so correct protocol is logged, and add tests for Windows named pipes.

#### How to host Sinopia in iisnode
With this PR Sinopia can be used in iisnode by creating a project, `npm install --save sinopia2` and then create `index.js`:
``` js
process.argv.push('--listen', process.env.PORT || '4873')
require('./node_modules/sinopia2/lib/cli')
```

Configure iisnode to use `index.js` as start file.


#### Named pipes
A named pipe in Windows has the format:
`\\.\pipe\PipeName`

- The period specifies the local computer
- The pipe name string specified by `PipeName` can include any character
other than a backslash, including numbers and special characters.

From: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx
